### PR TITLE
Upload before create partitoin

### DIFF
--- a/src/main/java/com/grupozap/dumping_machine/partitioners/HourlyBasedPartitioner.java
+++ b/src/main/java/com/grupozap/dumping_machine/partitioners/HourlyBasedPartitioner.java
@@ -167,14 +167,14 @@ public class HourlyBasedPartitioner {
 
                 Schema schema = hourlyBasedRecordConsumer.getSchema(path.getKey());
 
+                logger.info("Topic: " + this.topic + " - Uploading hourlyBasedRecordConsumer for " + this.topic + " path " + path.getValue());
+
+                this.uploader.upload(path.getValue(), path.getKey());
+
                 if (hiveTable != null) {
                     HiveClient hiveClient = new HiveClient(this.metaStoreUris);
                     HiveUtil.updateHive(hiveClient, hiveTable, schema, path.getValue(), this.uploader.getServerPath());
                 }
-
-                logger.info("Topic: " + this.topic + " - Uploading hourlyBasedRecordConsumer for " + this.topic + " path " + path.getValue());
-
-                this.uploader.upload(path.getValue(), path.getKey());
             }
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
The main reason of this change is to fix the order of the creation of a new partition in Hive. Currently the process create the new partition in Hive and then upload the new files. This order causes the incorrect partition statistics in Hive, because when a new partition is created, the Hive automatically collect the statistics of that partition. 

- [X] First upload the new files and then create the new partition.