### PR TITLE
Remove hive dependency on application start

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -21,3 +21,8 @@ topics:
   coreSitePath: file://core-site.xml
   hdfsSitePath: file://hdfs-site.xml
   partitionForget: 3000
+- name: topic-3
+  type: S3Uploader
+  bucketName: bucket-2
+  bucketRegion: us-east-1
+  partitionForget: 3000

--- a/src/main/java/com/grupozap/dumping_machine/streamers/KafkaStreamer.java
+++ b/src/main/java/com/grupozap/dumping_machine/streamers/KafkaStreamer.java
@@ -37,9 +37,11 @@ public class KafkaStreamer {
             Uploader uploader;
             HashMap<RecordType, String> hiveTables = new HashMap<>();
 
-            hiveTables.put(RecordType.RECORD, topicProperty.getHive().getRecordTable());
-            hiveTables.put(RecordType.ERROR, topicProperty.getHive().getErrorTable());
-            hiveTables.put(RecordType.TOMBSTONE, topicProperty.getHive().getTombstoneTable());
+            if(topicProperty.getHive() != null) {
+                hiveTables.put(RecordType.RECORD, topicProperty.getHive().getRecordTable());
+                hiveTables.put(RecordType.ERROR, topicProperty.getHive().getErrorTable());
+                hiveTables.put(RecordType.TOMBSTONE, topicProperty.getHive().getTombstoneTable());
+            }
 
             if(topicProperty.getType().equals("HDFSUploader")) {
                 uploader = new HDFSUploader(topicProperty.getHdfsPath(), topicProperty.getCoreSitePath(), topicProperty.getHdfsSitePath(), topicProperty.getTopicPath());

--- a/src/main/java/com/grupozap/dumping_machine/streamers/KafkaStreamer.java
+++ b/src/main/java/com/grupozap/dumping_machine/streamers/KafkaStreamer.java
@@ -36,8 +36,10 @@ public class KafkaStreamer {
         for(TopicProperties topicProperty : topicProperties) {
             Uploader uploader;
             HashMap<RecordType, String> hiveTables = new HashMap<>();
+            String metaStoreUris = null;
 
             if(topicProperty.getHive() != null) {
+                metaStoreUris = topicProperty.getHive().getUrl();
                 hiveTables.put(RecordType.RECORD, topicProperty.getHive().getRecordTable());
                 hiveTables.put(RecordType.ERROR, topicProperty.getHive().getErrorTable());
                 hiveTables.put(RecordType.TOMBSTONE, topicProperty.getHive().getTombstoneTable());
@@ -49,7 +51,7 @@ public class KafkaStreamer {
                 uploader = new S3Uploader(topicProperty.getBucketName(), topicProperty.getBucketRegion());
             }
 
-            TopicStreamer topicStreamer = new TopicStreamer(this.bootstrapServers, this.groupId, this.schemaRegistryUrl, this.sessionTimeout, uploader, topicProperty.getName(), topicProperty.getPoolTimeout(), topicProperty.getPartitionForget(), topicProperty.getHive().getUrl(), hiveTables);
+            TopicStreamer topicStreamer = new TopicStreamer(this.bootstrapServers, this.groupId, this.schemaRegistryUrl, this.sessionTimeout, uploader, topicProperty.getName(), topicProperty.getPoolTimeout(), topicProperty.getPartitionForget(), metaStoreUris, hiveTables);
 
             this.pool.execute(topicStreamer);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This changes are to avoid that `Hive` configurations be mandatory. For now, we are not using Hive and we would like just to dump from Kafka Topics to S3 ❤️ 

If you don't set Hive settings, it will throws a NullPointerException and it will crash if you use dummy settings like:

```
      hive:
        url: thrift://localhost:9083
        user: user
        password:
        recordTable: schema.table
        errorTable: schema.table_error
        tombstoneTable: schema.table_tombstone
```
